### PR TITLE
Fixing fatalError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [2.0.0](https://github.com/iKiKi/KTTagsView/releases/tag/2.0.0)
+Released on 2018-08-XX.
+
+#### Updated
+- In `TagsViewDataSource`, `tagsView(tagsView:,sizeForTagAt:)` have been renamed to `tagsView(tagsView:,preferredSizeForTagAt:)`. TagsView may now override the returned size to make sure its width doesn't exceed the current TagsView's width. The previous behaviour was to make a `fatalError` in this case while it's wasn't documented.
+
 ## [1.0.1](https://github.com/iKiKi/KTTagsView/releases/tag/1.0.1)
 Released on 2018-04-22.
 

--- a/Example/KTTagsView/KTTagsView iOS/Resources/Info.plist
+++ b/Example/KTTagsView/KTTagsView iOS/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Example/KTTagsView/KTTagsView tvOS/Resources/Info.plist
+++ b/Example/KTTagsView/KTTagsView tvOS/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Example/KTTagsView/KTTagsView.xcodeproj/project.pbxproj
+++ b/Example/KTTagsView/KTTagsView.xcodeproj/project.pbxproj
@@ -505,7 +505,6 @@
 				279B49AE2044BE3B003056D3 /* Frameworks */,
 				279B49AF2044BE3B003056D3 /* Resources */,
 				EF1A51A0CB0566B503EF6AD1 /* [CP] Embed Pods Frameworks */,
-				6EA4ECB5487F2DB41AE03E6D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -527,7 +526,6 @@
 				279B49EE2044C1D3003056D3 /* Frameworks */,
 				279B49EF2044C1D3003056D3 /* Resources */,
 				30FADEDE683A5FB3137B255A /* [CP] Embed Pods Frameworks */,
-				FA5A9D4BF62DA7DA50C97D2C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -722,21 +720,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6EA4ECB5487F2DB41AE03E6D /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-KTTagsView iOS/Pods-KTTagsView iOS-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		EF1A51A0CB0566B503EF6AD1 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -753,21 +736,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-KTTagsView iOS/Pods-KTTagsView iOS-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		FA5A9D4BF62DA7DA50C97D2C /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-KTTagsView tvOS/Pods-KTTagsView tvOS-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/KTTagsView/KTTagsView/Code/Constants/SwiftGen/Assets.swift
+++ b/Example/KTTagsView/KTTagsView/Code/Constants/SwiftGen/Assets.swift
@@ -44,11 +44,13 @@ internal struct ColorAsset {
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 internal enum Asset {
+  internal static let launch = ImageAsset(name: "launch")
 
   // swiftlint:disable trailing_comma
   internal static let allColors: [ColorAsset] = [
   ]
   internal static let allImages: [ImageAsset] = [
+    launch,
   ]
   // swiftlint:enable trailing_comma
   @available(*, deprecated, renamed: "allImages")

--- a/Example/KTTagsView/KTTagsView/Code/Constants/SwiftGen/Storyboards.swift
+++ b/Example/KTTagsView/KTTagsView/Code/Constants/SwiftGen/Storyboards.swift
@@ -53,10 +53,15 @@ internal extension UIViewController {
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
+  internal enum LaunchScreen: StoryboardType {
+    internal static let storyboardName = "LaunchScreen"
+
+    internal static let initialScene = InitialSceneType<UIViewController>(storyboard: LaunchScreen.self)
+  }
   internal enum Main: StoryboardType {
     internal static let storyboardName = "Main"
 
-    internal static let mainViewController = SceneType<KTTagsView_tvOS.MainViewController>(storyboard: Main.self, identifier: "MainViewController")
+    internal static let mainViewController = SceneType<KTTagsView_iOS.MainViewController>(storyboard: Main.self, identifier: "MainViewController")
   }
 }
 

--- a/Example/KTTagsView/KTTagsView/Code/ViewModels/TagsViewModel.swift
+++ b/Example/KTTagsView/KTTagsView/Code/ViewModels/TagsViewModel.swift
@@ -121,7 +121,7 @@ final class TagsViewModel: TagsProvider {
 // MARK: - TagsViewDataSource
 extension TagsViewModel: TagsViewDataSource {
   
-  func tagsView(_ tagsView: TagsView, sizeForTagAt index: Int) -> CGSize {
+  func tagsView(_ tagsView: TagsView, preferredSizeForTagAt index: Int) -> CGSize {
     let tag = self.tags[index]
     return MyTagView.preferredSize(with: tagsView.bounds.size, tag: tag, at: index)
   }

--- a/Example/KTTagsView/KTTagsView/Code/Views/CustomViews/MyTagView.swift
+++ b/Example/KTTagsView/KTTagsView/Code/Views/CustomViews/MyTagView.swift
@@ -74,10 +74,7 @@ extension MyTagView: TagSizable {
     let adjustedSize = CGSize(width: contentSize.width - margins, height: contentSize.height - margins)
     let width = UILabel.width(fitting: adjustedSize, string: tag, attributes: MyTagView.tagAttributes)
     let height = UILabel.height(fitting: adjustedSize, string: tag, attributes: MyTagView.tagAttributes)
-    // Uncomment to assert the width too large fatal error
-//    return CGSize(width: width, height: height)
-    let constrainedWidth: CGFloat = min(contentSize.width, width + margins)
-    return CGSize(width: constrainedWidth, height: height + margins)
+    return CGSize(width: width + margins, height: height + margins)
   }
 }
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - KTTagsView (1.0.0)
+  - KTTagsView (2.0.0)
   - Reusable (4.0.2):
     - Reusable/Storyboard (= 4.0.2)
     - Reusable/View (= 4.0.2)
@@ -14,16 +14,22 @@ DEPENDENCIES:
   - SwiftGen (~> 5.3.0)
   - SwiftLint (~> 0.25.0)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Reusable
+    - SwiftGen
+    - SwiftLint
+
 EXTERNAL SOURCES:
   KTTagsView:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  KTTagsView: ee991b7c48587297429ef37484651bfa3b07c17b
+  KTTagsView: 57ca67b1efe00e63511bbf59f3debc81e3dce42f
   Reusable: 584a5629747c52e0f6a77841b400dc2643f6fa0f
   SwiftGen: 4379bd3640b0a212a0f6ea3c494adba385513d10
   SwiftLint: e14651157288e9e01d6e1a71db7014fb5744a8ea
 
 PODFILE CHECKSUM: aabb0b6ffb5035844b828bc35c687559c06737b1
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.3

--- a/KTTagsView.podspec
+++ b/KTTagsView.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name                     = 'KTTagsView'
-  spec.version                  = '1.0.1'
+  spec.version                  = '2.0.0'
   spec.swift_version            = '4.0'
   spec.cocoapods_version        = '>= 1.4.0'
   spec.author                   = { "Killian THORON" => "killian.thoron@gmail.com" }

--- a/Sources/TagsView.swift
+++ b/Sources/TagsView.swift
@@ -23,7 +23,7 @@
 import UIKit
 
 public protocol TagsViewDataSource: class {
-  func tagsView(_ tagsView: TagsView, sizeForTagAt index: Int) -> CGSize
+  func tagsView(_ tagsView: TagsView, preferredSizeForTagAt index: Int) -> CGSize
   func tagsView(_ tagsView: TagsView, viewForTagAt index: Int) -> UIView
 }
 
@@ -137,13 +137,10 @@ private extension TagsView {
     var rowWidth: CGFloat = self.minimumIntertagSpacing
     var rowHeight: CGFloat = 0
     for index in 0..<self.nbOfTags {
-      let size = dataSource.tagsView(self, sizeForTagAt: index)
+      var size = dataSource.tagsView(self, preferredSizeForTagAt: index)
 
-      guard
-        size.width <= self.bounds.width
-      else {
-        fatalError("The size: \(size) returned for the tag at index: \(index) is larger than the \(TagsView.self) bounds: \(self.bounds). Please review your implementation")
-      }
+      // Make sure the tag's width won't exceed the current width
+      size.width = min(size.width, self.bounds.width)
 
       let width = size.width + self.minimumIntertagSpacing
       let remainingWidth: CGFloat = self.bounds.width - rowWidth


### PR DESCRIPTION
While not documented, returning a too large size in `TagsViewDataSource`'s `tagsView(:sizeForTag:)` would result in a fatalError.
Now the retuned size will be overidden to make sure it's maxed to the current width.